### PR TITLE
Add python services

### DIFF
--- a/interoptest/src/pythonservice/__init__.py
+++ b/interoptest/src/pythonservice/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/interoptest/src/pythonservice/flaskserver.py
+++ b/interoptest/src/pythonservice/flaskserver.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+
+from contextlib import contextmanager
+import logging
+import sys
+
+from concurrent import futures
+from opencensus.trace.ext.flask import flask_middleware
+import flask
+import requests
+
+import interoperability_test_pb2 as pb2
+import service
+import test_service
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+app = flask.Flask(__name__)
+
+# Enable tracing the requests
+flask_middleware.FlaskMiddleware(app)
+
+
+@app.route(service.HTTP_POST_PATH, methods=['POST'])
+def test():
+    request = pb2.TestRequest.FromString(flask.request.get_data())
+    logger.debug("Got request: %s", request)
+
+    if not request.service_hops:
+        response = pb2.TestResponse(
+            id=request.id,
+            status=[pb2.CommonResponseStatus(
+                status=pb2.SUCCESS,
+            )],
+        )
+    else:
+        response = service.call_next(request)
+    return response.SerializeToString()
+
+
+# http://flask.pocoo.org/snippets/67/
+def shutdown_server():
+    func = flask.request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+
+
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    shutdown_server()
+    return "Shutting down server"
+
+
+@contextmanager
+def serve_http_tracecontext(
+        port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+    host = 'localhost'
+    with futures.ThreadPoolExecutor(max_workers=1) as tpe:
+        tpe.submit(app.run, host=host, port=port)
+        yield app
+        requests.post('http://{}:{}{}'.format(host, port, '/shutdown'))
+    logger.debug("Shut down flask server")
+
+
+if __name__ == '__main__':
+    with serve_http_tracecontext():
+        test_service.test_http_server()

--- a/interoptest/src/pythonservice/flaskserver.py
+++ b/interoptest/src/pythonservice/flaskserver.py
@@ -50,6 +50,7 @@ def healthcheck():
 
 @app.route(service.HTTP_POST_PATH, methods=['POST'])
 def test():
+    """Handle a test request by calling other test services"""
     request = pb2.TestRequest.FromString(flask.request.get_data())
     logger.debug("Got request: %s", request)
 
@@ -67,6 +68,7 @@ def test():
 
 # http://flask.pocoo.org/snippets/67/
 def shutdown_server():
+    """Shug down the server."""
     func = flask.request.environ.get('werkzeug.server.shutdown')
     if func is None:
         raise RuntimeError('Not running with the Werkzeug Server')
@@ -75,12 +77,14 @@ def shutdown_server():
 
 @app.route('/shutdown', methods=['POST'])
 def shutdown():
+    """Handler to shut down the server."""
     shutdown_server()
     return "Shutting down server"
 
 
 @app.route('/register', methods=['POST'])
 def register(port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+    """Register the server at host:port with the test registration service."""
     request = pb2.RegistrationRequest(
         server_name='python',
         services=[
@@ -123,6 +127,7 @@ def block_until_ready(host, port, timeout=10):
 @contextmanager
 def serve_http_tracecontext(
         port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+    """Run the HTTP/tracecontext server, shut down on exiting context."""
     host = 'localhost'
     with futures.ThreadPoolExecutor(max_workers=1) as tpe:
         tpe.submit(app.run, host=host, port=port)

--- a/interoptest/src/pythonservice/grpcserver.py
+++ b/interoptest/src/pythonservice/grpcserver.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+
+from concurrent import futures
+from contextlib import contextmanager
+import logging
+import sys
+
+from opencensus.trace.exporters import logging_exporter
+from opencensus.trace.ext.grpc import server_interceptor
+from opencensus.trace.samplers import always_on
+import grpc
+
+import interoperability_test_pb2 as pb2
+import interoperability_test_pb2_grpc as pb2_grpc
+import service
+import util
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+GRPC_TPE_WORKERS = 10
+
+
+class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
+
+    def test(self, request, context):
+        logger.debug("grpc service recieved: %s", request)
+        if not request.service_hops:
+            response = pb2.TestResponse(
+                id=request.id,
+                status=[pb2.CommonResponseStatus(
+                    status=pb2.SUCCESS,
+                )],
+            )
+        else:
+            response = service.call_next(request)
+        return response
+
+
+def register(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    request = pb2.RegistrationRequest(
+        server_name='python',
+        services=[
+            pb2.Service(
+                name='python',
+                port=port,
+                host=host,
+                spec=pb2.Spec(
+                    transport=pb2.Spec.GRPC,
+                    propagation=pb2.Spec.BINARY_FORMAT_PROPAGATION)
+            )])
+    client = pb2_grpc.RegistrationServiceStub(
+        channel=grpc.insecure_channel(
+            '{}:{}'.format(service.REGISTRATION_SERVER_HOST,
+                           service.REGISTRATION_SERVER_PORT))
+    )
+    return client.register(request)
+
+
+@contextmanager
+def serve_grpc_binary(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    interceptor = server_interceptor.OpenCensusServerInterceptor(
+        always_on.AlwaysOnSampler(), logging_exporter.LoggingExporter())
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=GRPC_TPE_WORKERS),
+        interceptors=(interceptor,)
+    )
+    pb2_grpc.add_TestExecutionServiceServicer_to_server(
+        GRPCBinaryTestServer(),
+        server
+    )
+    server.add_insecure_port('[::]:{}'.format(port))
+    try:
+        server.start()
+        yield server
+    finally:
+        server.stop(0)
+
+
+def test_server(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    """Send a single multi-hop request to the server and shut it down."""
+
+    test_request = pb2.TestRequest(
+        name="python:grpc:binary",
+        service_hops=[
+            pb2.ServiceHop(
+                service=pb2.Service(
+                    name="python:grpc:binary",
+                    port=port,
+                    host="localhost",
+                    spec=pb2.Spec(
+                        transport=pb2.Spec.GRPC,
+                        propagation=pb2.Spec.BINARY_FORMAT_PROPAGATION))),
+            pb2.ServiceHop(
+                service=pb2.Service(
+                    name="python:grpc:binary",
+                    port=port,
+                    host="localhost",
+                    spec=pb2.Spec(
+                        transport=pb2.Spec.GRPC,
+                        propagation=pb2.Spec.BINARY_FORMAT_PROPAGATION)))
+        ])
+
+    with serve_grpc_binary():
+        return service.call_grpc_binary('localhost', port, test_request)
+
+
+def main(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT,
+         exit_event=None):
+    """Runs the service and registers it with the test coordinator."""
+    with serve_grpc_binary():
+        try:
+            logger.debug("Registering with test coordinator")
+            register(host, port)
+        except grpc.RpcError as ex:
+            logger.info(
+                "Registration server call failed with exception: %s", ex)
+        logger.debug("Serving...")
+        if exit_event is not None:
+            while not exit_event.is_set():
+                exit_event.wait(60)
+
+
+if __name__ == "__main__":
+    with util.get_signal_exit() as _exit_event:
+        main(exit_event=_exit_event)

--- a/interoptest/src/pythonservice/grpcserver.py
+++ b/interoptest/src/pythonservice/grpcserver.py
@@ -37,13 +37,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
-
 GRPC_TPE_WORKERS = 10
 
 
 class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
 
     def test(self, request, context):
+        """Handle a test request by calling other test services"""
         logger.debug("grpc service recieved: %s", request)
         if not request.service_hops:
             response = pb2.TestResponse(
@@ -58,6 +58,7 @@ class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
 
 
 def register(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    """Register the server at host:port with the test registration service."""
     request = pb2.RegistrationRequest(
         server_name='python',
         services=[
@@ -79,6 +80,7 @@ def register(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
 
 @contextmanager
 def serve_grpc_binary(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    """Run the GRPC/binary server, shut down on exiting context."""
     interceptor = server_interceptor.OpenCensusServerInterceptor(
         always_on.AlwaysOnSampler(), logging_exporter.LoggingExporter())
     server = grpc.server(

--- a/interoptest/src/pythonservice/httpserver.py
+++ b/interoptest/src/pythonservice/httpserver.py
@@ -1,0 +1,83 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+
+from concurrent import futures
+from contextlib import contextmanager
+import logging
+import sys
+
+import interoperability_test_pb2 as pb2
+import service
+
+try:
+    from http.server import BaseHTTPRequestHandler
+    from http.server import HTTPServer
+    import socketserver
+except ImportError:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+    from BaseHTTPServer import HTTPServer
+    import SocketServer as socketserver
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+class HTTPTraceContextTestServer(BaseHTTPRequestHandler):
+
+    def do_POST(self):
+        if self.path != service.HTTP_POST_PATH:
+            self.send_error(404)
+            return
+
+        length = int(self.headers['Content-Length'])
+        message = self.rfile.read(length)
+        request = pb2.TestRequest.FromString(message)
+        logger.debug("http service recieved: %s", request)
+
+        if not request.service_hops:
+            response = pb2.TestResponse(
+                id=request.id,
+                status=[pb2.CommonResponseStatus(
+                    status=pb2.SUCCESS,
+                )],
+            )
+        else:
+            response = service.call_next(request)
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(response.SerializeToString())
+
+
+# Stolen from http.server in python 3.7, here for backwards compatability. See
+# https://docs.python.org/3.7/library/http.server.html.
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+@contextmanager
+def serve_http_tracecontext(
+        port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+    httpd = ThreadingHTTPServer(('', port), HTTPTraceContextTestServer)
+    with futures.ThreadPoolExecutor(max_workers=1) as tpe:
+        tpe.submit(httpd.serve_forever)
+        yield httpd
+        httpd.shutdown()

--- a/interoptest/src/pythonservice/pythonservice.py
+++ b/interoptest/src/pythonservice/pythonservice.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-#
+#!/usr/bin/env python
+
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,38 +14,318 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
 
-from logger import getJSONLogger
-logger = getJSONLogger('pythonservice')
+from collections import namedtuple
+from concurrent import futures
+from contextlib import contextmanager
+from uuid import uuid4
+import logging
+import sys
 
-from BaseHTTPServer import BaseHTTPRequestHandler,HTTPServer
+import grpc
+import requests
 
-PORT_NUMBER = 10401
-
-#This class will handles any incoming request from
-#the browser 
-class myHandler(BaseHTTPRequestHandler):
-	
-	#Handler for the GET requests
-	def do_GET(self):
-		self.send_response(200)
-		self.send_header('Content-type','text/html')
-		self.end_headers()
-		# Send the html message
-		self.wfile.write("Hello World !")
-		return
+import interoperability_test_pb2 as pb2
+import interoperability_test_pb2_grpc as pb2_grpc
 
 try:
-	#Create a web server and define the handler to manage the
-	#incoming request
-	server = HTTPServer(('', PORT_NUMBER), myHandler)
-	print 'Started httpserver on port ' , PORT_NUMBER
-	
-	#Wait forever for incoming htto requests
-	server.serve_forever()
+    from http.server import BaseHTTPRequestHandler
+    from http.server import HTTPServer
+    import socketserver
+except ImportError:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+    from BaseHTTPServer import HTTPServer
+    import SocketServer as socketserver
 
-except KeyboardInterrupt:
-	print '^C received, shutting down the web server'
-	server.socket.close()
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+GRPC_TPE_WORKERS = 10
+HTTP_POST_PATH = "/test/request/"
+
+
+PORT_MAP = {
+    pb2.JAVA_GRPC_BINARY_PROPAGATION_PORT:
+    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.JAVA_HTTP_B3_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.JAVA_HTTP_TRACECONTEXT_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
+    pb2.GO_GRPC_BINARY_PROPAGATION_PORT:
+    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.GO_HTTP_B3_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.GO_HTTP_TRACECONTEXT_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
+    pb2.NODEJS_GRPC_BINARY_PROPAGATION_PORT:
+    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.NODEJS_HTTP_TRACECONTEXT_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
+    pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT:
+    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
+    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT:
+    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.CPP_HTTP_B3_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT:
+    (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
+}
+
+
+def rand63():
+    """Get a random positive 63 bit int"""
+    return uuid4().int >> 65
+
+
+def call_http(host, port, request):
+    """Call the HTTP service at host:port with the given request."""
+
+    logger.debug("Called call_http at %s:%s, hops left: %s", host, port,
+                 len(request.service_hops))
+    data = request.SerializeToString()
+    response = requests.post(
+        'http://{}:{}{}'.format(host, port, HTTP_POST_PATH),
+        data=data
+    )
+    response.raise_for_status()
+    logger.debug("http service responded: %s", response)
+    return pb2.TestResponse.FromString(response.content)
+
+
+call_http_b3 = call_http
+call_http_tracecontext = call_http
+
+
+def call_grpc_binary(host, port, request):
+    """Call the GRPC/binary service at host:port with the given request."""
+
+    logger.debug("Called call_grpc_binary at %s:%s, hops left: %s", host, port,
+                 len(request.service_hops))
+    client = pb2_grpc.TestExecutionServiceStub(
+        channel=grpc.insecure_channel('{}:{}'.format(host, port))
+    )
+    response = client.test(request)
+    logger.debug("grpc service responded: %s", response)
+    return response
+
+
+def call_next(request):
+    """Call the next service given by request.service_hops."""
+
+    if not request.service_hops:
+        raise ValueError()
+
+    new_request = pb2.TestRequest(
+        id=request.id,
+        name=request.name,
+        service_hops=request.service_hops[1:]
+    )
+
+    next_hop = request.service_hops[0]
+    transport = next_hop.service.spec.transport
+    prop = next_hop.service.spec.propagation
+    host = next_hop.service.host
+    port = next_hop.service.port
+
+    if port not in PORT_MAP:
+        raise ValueError()
+    if (transport, prop) != PORT_MAP[port]:
+        raise ValueError()
+
+    if (transport == pb2.Spec.HTTP
+            and prop == pb2.Spec.B3_FORMAT_PROPAGATION):
+        return call_http_b3(host, port, new_request)
+    if (transport == pb2.Spec.HTTP
+            and prop == pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION):
+        return call_http_tracecontext(host, port, new_request)
+    if (transport == pb2.Spec.GRPC
+            and prop == pb2.Spec.BINARY_FORMAT_PROPAGATION):
+        return call_grpc_binary(host, port, new_request)
+    raise ValueError("No service for transport/propagation")
+
+
+class HTTPTraceContextTestServer(BaseHTTPRequestHandler):
+
+    def do_POST(self):
+        if self.path != HTTP_POST_PATH:
+            self.send_error(404)
+            return
+
+        length = int(self.headers['Content-Length'])
+        message = self.rfile.read(length)
+        request = pb2.TestRequest.FromString(message)
+        logger.debug("http service recieved: %s", request)
+
+        if not request.service_hops:
+            response = pb2.TestResponse(
+                id=request.id,
+                status=[pb2.CommonResponseStatus(
+                    status=pb2.SUCCESS,
+                )],
+            )
+        else:
+            response = call_next(request)
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(response.SerializeToString())
+
+
+# Stolen from http.server in python 3.7, here for backwards compatability. See
+# https://docs.python.org/3.7/library/http.server.html.
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+@contextmanager
+def serve_http_tracecontext(
+        port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+    httpd = ThreadingHTTPServer(('', port), HTTPTraceContextTestServer)
+    with futures.ThreadPoolExecutor(max_workers=1) as tpe:
+        tpe.submit(httpd.serve_forever)
+        yield httpd
+        httpd.shutdown()
+
+
+class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
+
+    def test(self, request, context):
+        logger.debug("grpc service recieved: %s", request)
+        if not request.service_hops:
+            response = pb2.TestResponse(
+                id=request.id,
+                status=[pb2.CommonResponseStatus(
+                    status=pb2.SUCCESS,
+                )],
+            )
+        else:
+            response = call_next(request)
+        return response
+
+
+@contextmanager
+def serve_grpc_binary(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=GRPC_TPE_WORKERS))
+    pb2_grpc.add_TestExecutionServiceServicer_to_server(
+        GRPCBinaryTestServer(),
+        server
+    )
+    server.add_insecure_port('[::]:{}'.format(port))
+    try:
+        server.start()
+        yield server
+    finally:
+        server.stop(0)
+
+
+TRANSPORT_TO_TRANSPORT_NAME = {
+    pb2.Spec.HTTP: 'http',
+    pb2.Spec.GRPC: 'grpc',
+}
+
+PROP_TO_PROP_NAME = {
+    pb2.Spec.B3_FORMAT_PROPAGATION: 'b3',
+    pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION: 'tracecontext',
+    pb2.Spec.BINARY_FORMAT_PROPAGATION: 'binary',
+}
+
+PORT_TO_LANG_NAME = {
+    pb2.JAVA_GRPC_BINARY_PROPAGATION_PORT: 'java',
+    pb2.JAVA_HTTP_B3_PROPAGATION_PORT: 'java',
+    pb2.JAVA_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'java',
+    pb2.GO_GRPC_BINARY_PROPAGATION_PORT: 'go',
+    pb2.GO_HTTP_B3_PROPAGATION_PORT: 'go',
+    pb2.GO_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'go',
+    pb2.NODEJS_GRPC_BINARY_PROPAGATION_PORT: 'nodejs',
+    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT: 'nodejs',
+    pb2.NODEJS_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'nodejs',
+    pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT: 'python',
+    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT: 'python',
+    pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'python',
+    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT: 'cpp',
+    pb2.CPP_HTTP_B3_PROPAGATION_PORT: 'cpp',
+    pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'cpp',
+}
+
+
+Hop = namedtuple('Hop', ('host', 'port', 'transport', 'prop'))
+
+
+def get_name(hop):
+    return "{}:{}:{}".format(
+        PORT_TO_LANG_NAME.get(hop.port, 'unknown'),
+        TRANSPORT_TO_TRANSPORT_NAME.get(hop.transport, 'unknown'),
+        PROP_TO_PROP_NAME.get(hop.prop, 'unknown'),
+    )
+
+
+def build_request(hops, id_=None):
+    if id_ is None:
+        id_ = rand63()
+
+    def build_service_hop(hop):
+        return pb2.ServiceHop(
+            service=pb2.Service(
+                name=get_name(hop),
+                port=hop.port,
+                host=hop.host,
+                spec=pb2.Spec(
+                    transport=hop.transport,
+                    propagation=hop.prop,
+                )
+            )
+        )
+
+    return pb2.TestRequest(
+        id=id_,
+        name=get_name(hops[0]),
+        service_hops=[build_service_hop(hop) for hop in hops]
+    )
+
+
+HTTP = pb2.Spec.HTTP
+GRPC = pb2.Spec.GRPC
+B3 = pb2.Spec.B3_FORMAT_PROPAGATION
+TRACECONTEXT = pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION
+BINARY = pb2.Spec.BINARY_FORMAT_PROPAGATION
+
+OWN_HOST = 'localhost'
+OWN_HTTP_PORT = pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT
+OWN_GRPC_PORT = pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT
+
+
+def test_http_server():
+    test_request = build_request([
+        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
+        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
+    ])
+    with serve_http_tracecontext():
+        return call_http_tracecontext(OWN_HOST, OWN_HTTP_PORT, test_request)
+
+
+def test_grpc_server():
+    test_request = build_request([
+        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
+        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
+    ])
+    with serve_grpc_binary():
+        return call_grpc_binary('localhost', OWN_GRPC_PORT, test_request)
+
+
+if __name__ == '__main__':
+    test_http_server()
+    test_grpc_server()

--- a/interoptest/src/pythonservice/requirements.txt
+++ b/interoptest/src/pythonservice/requirements.txt
@@ -1,4 +1,5 @@
 grpcio
+flask
 opencensus
 protobuf
 requests

--- a/interoptest/src/pythonservice/requirements.txt
+++ b/interoptest/src/pythonservice/requirements.txt
@@ -1,3 +1,3 @@
-cachetools==2.1.0
-certifi==2018.4.16
-python-json-logger==0.1.9
+protobuf
+grpcio
+requests

--- a/interoptest/src/pythonservice/requirements.txt
+++ b/interoptest/src/pythonservice/requirements.txt
@@ -1,3 +1,5 @@
-protobuf
 grpcio
+opencensus
+protobuf
 requests
+wrapt  # see https://github.com/census-instrumentation/opencensus-python/pull/432

--- a/interoptest/src/pythonservice/requirements_py2.txt
+++ b/interoptest/src/pythonservice/requirements_py2.txt
@@ -1,0 +1,1 @@
+futures

--- a/interoptest/src/pythonservice/requirements_py2.txt
+++ b/interoptest/src/pythonservice/requirements_py2.txt
@@ -1,1 +1,2 @@
+contextlib2
 futures

--- a/interoptest/src/pythonservice/service.py
+++ b/interoptest/src/pythonservice/service.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +17,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=too-few-public-methods
 
-from collections import namedtuple
 from concurrent import futures
 from contextlib import contextmanager
 from uuid import uuid4
@@ -230,102 +227,3 @@ def serve_grpc_binary(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
         yield server
     finally:
         server.stop(0)
-
-
-TRANSPORT_TO_TRANSPORT_NAME = {
-    pb2.Spec.HTTP: 'http',
-    pb2.Spec.GRPC: 'grpc',
-}
-
-PROP_TO_PROP_NAME = {
-    pb2.Spec.B3_FORMAT_PROPAGATION: 'b3',
-    pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION: 'tracecontext',
-    pb2.Spec.BINARY_FORMAT_PROPAGATION: 'binary',
-}
-
-PORT_TO_LANG_NAME = {
-    pb2.JAVA_GRPC_BINARY_PROPAGATION_PORT: 'java',
-    pb2.JAVA_HTTP_B3_PROPAGATION_PORT: 'java',
-    pb2.JAVA_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'java',
-    pb2.GO_GRPC_BINARY_PROPAGATION_PORT: 'go',
-    pb2.GO_HTTP_B3_PROPAGATION_PORT: 'go',
-    pb2.GO_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'go',
-    pb2.NODEJS_GRPC_BINARY_PROPAGATION_PORT: 'nodejs',
-    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT: 'nodejs',
-    pb2.NODEJS_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'nodejs',
-    pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT: 'python',
-    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT: 'python',
-    pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'python',
-    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT: 'cpp',
-    pb2.CPP_HTTP_B3_PROPAGATION_PORT: 'cpp',
-    pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'cpp',
-}
-
-
-Hop = namedtuple('Hop', ('host', 'port', 'transport', 'prop'))
-
-
-def get_name(hop):
-    return "{}:{}:{}".format(
-        PORT_TO_LANG_NAME.get(hop.port, 'unknown'),
-        TRANSPORT_TO_TRANSPORT_NAME.get(hop.transport, 'unknown'),
-        PROP_TO_PROP_NAME.get(hop.prop, 'unknown'),
-    )
-
-
-def build_request(hops, id_=None):
-    if id_ is None:
-        id_ = rand63()
-
-    def build_service_hop(hop):
-        return pb2.ServiceHop(
-            service=pb2.Service(
-                name=get_name(hop),
-                port=hop.port,
-                host=hop.host,
-                spec=pb2.Spec(
-                    transport=hop.transport,
-                    propagation=hop.prop,
-                )
-            )
-        )
-
-    return pb2.TestRequest(
-        id=id_,
-        name=get_name(hops[0]),
-        service_hops=[build_service_hop(hop) for hop in hops]
-    )
-
-
-HTTP = pb2.Spec.HTTP
-GRPC = pb2.Spec.GRPC
-B3 = pb2.Spec.B3_FORMAT_PROPAGATION
-TRACECONTEXT = pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION
-BINARY = pb2.Spec.BINARY_FORMAT_PROPAGATION
-
-OWN_HOST = 'localhost'
-OWN_HTTP_PORT = pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT
-OWN_GRPC_PORT = pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT
-
-
-def test_http_server():
-    test_request = build_request([
-        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
-        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
-    ])
-    with serve_http_tracecontext():
-        return call_http_tracecontext(OWN_HOST, OWN_HTTP_PORT, test_request)
-
-
-def test_grpc_server():
-    test_request = build_request([
-        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
-        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
-    ])
-    with serve_grpc_binary():
-        return call_grpc_binary('localhost', OWN_GRPC_PORT, test_request)
-
-
-if __name__ == '__main__':
-    test_http_server()
-    test_grpc_server()

--- a/interoptest/src/pythonservice/service.py
+++ b/interoptest/src/pythonservice/service.py
@@ -23,8 +23,10 @@ from uuid import uuid4
 import logging
 import sys
 
+from opencensus.trace.tracers import context_tracer
 from opencensus.trace.exporters import logging_exporter
 from opencensus.trace.ext.grpc import server_interceptor
+from opencensus.trace.ext import requests as requests_wrapper
 from opencensus.trace.samplers import always_on
 import grpc
 import requests
@@ -40,6 +42,10 @@ except ImportError:
     from BaseHTTPServer import BaseHTTPRequestHandler
     from BaseHTTPServer import HTTPServer
     import SocketServer as socketserver
+
+
+# Monkey patch the requests library
+requests_wrapper.trace.trace_integration(context_tracer.ContextTracer())
 
 
 logger = logging.getLogger(__name__)

--- a/interoptest/src/pythonservice/service.py
+++ b/interoptest/src/pythonservice/service.py
@@ -21,14 +21,13 @@ from uuid import uuid4
 import logging
 import sys
 
-from opencensus.trace.tracers import context_tracer
 from opencensus.trace.ext import requests as requests_wrapper
+from opencensus.trace.tracers import context_tracer
 import grpc
 import requests
 
 import interoperability_test_pb2 as pb2
 import interoperability_test_pb2_grpc as pb2_grpc
-
 
 # Monkey patch the requests library
 requests_wrapper.trace.trace_integration(context_tracer.ContextTracer())
@@ -46,32 +45,32 @@ HTTP_POST_PATH = "/test/request/"
 PORT_MAP = {
     pb2.JAVA_GRPC_BINARY_PROPAGATION_PORT:
     (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
-    pb2.JAVA_HTTP_B3_PROPAGATION_PORT:
-    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.JAVA_HTTP_B3_PROPAGATION_PORT: (pb2.Spec.HTTP,
+                                        pb2.Spec.B3_FORMAT_PROPAGATION),
     pb2.JAVA_HTTP_TRACECONTEXT_PROPAGATION_PORT:
     (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
-    pb2.GO_GRPC_BINARY_PROPAGATION_PORT:
-    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
-    pb2.GO_HTTP_B3_PROPAGATION_PORT:
-    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.GO_GRPC_BINARY_PROPAGATION_PORT: (pb2.Spec.GRPC,
+                                          pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.GO_HTTP_B3_PROPAGATION_PORT: (pb2.Spec.HTTP,
+                                      pb2.Spec.B3_FORMAT_PROPAGATION),
     pb2.GO_HTTP_TRACECONTEXT_PROPAGATION_PORT:
     (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
     pb2.NODEJS_GRPC_BINARY_PROPAGATION_PORT:
     (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
-    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT:
-    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT: (pb2.Spec.HTTP,
+                                          pb2.Spec.B3_FORMAT_PROPAGATION),
     pb2.NODEJS_HTTP_TRACECONTEXT_PROPAGATION_PORT:
     (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
     pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT:
     (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
-    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT:
-    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT: (pb2.Spec.HTTP,
+                                          pb2.Spec.B3_FORMAT_PROPAGATION),
     pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT:
     (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
-    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT:
-    (pb2.Spec.GRPC, pb2.Spec.BINARY_FORMAT_PROPAGATION),
-    pb2.CPP_HTTP_B3_PROPAGATION_PORT:
-    (pb2.Spec.HTTP, pb2.Spec.B3_FORMAT_PROPAGATION),
+    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT: (pb2.Spec.GRPC,
+                                           pb2.Spec.BINARY_FORMAT_PROPAGATION),
+    pb2.CPP_HTTP_B3_PROPAGATION_PORT: (pb2.Spec.HTTP,
+                                       pb2.Spec.B3_FORMAT_PROPAGATION),
     pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT:
     (pb2.Spec.HTTP, pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION),
 }
@@ -89,9 +88,7 @@ def call_http(host, port, request):
                  len(request.service_hops))
     data = request.SerializeToString()
     response = requests.post(
-        'http://{}:{}{}'.format(host, port, HTTP_POST_PATH),
-        data=data
-    )
+        'http://{}:{}{}'.format(host, port, HTTP_POST_PATH), data=data)
     response.raise_for_status()
     logger.debug("http service responded: %s", response)
     return pb2.TestResponse.FromString(response.content)
@@ -107,8 +104,7 @@ def call_grpc_binary(host, port, request):
     logger.debug("Called call_grpc_binary at %s:%s, hops left: %s", host, port,
                  len(request.service_hops))
     client = pb2_grpc.TestExecutionServiceStub(
-        channel=grpc.insecure_channel('{}:{}'.format(host, port))
-    )
+        channel=grpc.insecure_channel('{}:{}'.format(host, port)))
     response = client.test(request)
     logger.debug("grpc service responded: %s", response)
     return response
@@ -123,8 +119,7 @@ def call_next(request):
     new_request = pb2.TestRequest(
         id=request.id,
         name=request.name,
-        service_hops=request.service_hops[1:]
-    )
+        service_hops=request.service_hops[1:])
 
     next_hop = request.service_hops[0]
     transport = next_hop.service.spec.transport
@@ -137,8 +132,7 @@ def call_next(request):
     if (transport, prop) != PORT_MAP[port]:
         raise ValueError()
 
-    if (transport == pb2.Spec.HTTP
-            and prop == pb2.Spec.B3_FORMAT_PROPAGATION):
+    if (transport == pb2.Spec.HTTP and prop == pb2.Spec.B3_FORMAT_PROPAGATION):
         return call_http_b3(host, port, new_request)
     if (transport == pb2.Spec.HTTP
             and prop == pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION):

--- a/interoptest/src/pythonservice/test_service.py
+++ b/interoptest/src/pythonservice/test_service.py
@@ -22,6 +22,7 @@
 from collections import namedtuple
 
 import interoperability_test_pb2 as pb2
+import flaskserver
 import service
 
 TRANSPORT_TO_TRANSPORT_NAME = {
@@ -52,7 +53,6 @@ PORT_TO_LANG_NAME = {
     pb2.CPP_HTTP_B3_PROPAGATION_PORT: 'cpp',
     pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'cpp',
 }
-
 
 Hop = namedtuple('Hop', ('host', 'port', 'transport', 'prop'))
 

--- a/interoptest/src/pythonservice/test_service.py
+++ b/interoptest/src/pythonservice/test_service.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=no-member
+# pylint: disable=invalid-name
+# pylint: disable=missing-docstring
+# pylint: disable=too-few-public-methods
+
+from collections import namedtuple
+
+import interoperability_test_pb2 as pb2
+import service
+
+TRANSPORT_TO_TRANSPORT_NAME = {
+    pb2.Spec.HTTP: 'http',
+    pb2.Spec.GRPC: 'grpc',
+}
+
+PROP_TO_PROP_NAME = {
+    pb2.Spec.B3_FORMAT_PROPAGATION: 'b3',
+    pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION: 'tracecontext',
+    pb2.Spec.BINARY_FORMAT_PROPAGATION: 'binary',
+}
+
+PORT_TO_LANG_NAME = {
+    pb2.JAVA_GRPC_BINARY_PROPAGATION_PORT: 'java',
+    pb2.JAVA_HTTP_B3_PROPAGATION_PORT: 'java',
+    pb2.JAVA_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'java',
+    pb2.GO_GRPC_BINARY_PROPAGATION_PORT: 'go',
+    pb2.GO_HTTP_B3_PROPAGATION_PORT: 'go',
+    pb2.GO_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'go',
+    pb2.NODEJS_GRPC_BINARY_PROPAGATION_PORT: 'nodejs',
+    pb2.NODEJS_HTTP_B3_PROPAGATION_PORT: 'nodejs',
+    pb2.NODEJS_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'nodejs',
+    pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT: 'python',
+    pb2.PYTHON_HTTP_B3_PROPAGATION_PORT: 'python',
+    pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'python',
+    pb2.CPP_GRPC_BINARY_PROPAGATION_PORT: 'cpp',
+    pb2.CPP_HTTP_B3_PROPAGATION_PORT: 'cpp',
+    pb2.CPP_HTTP_TRACECONTEXT_PROPAGATION_PORT: 'cpp',
+}
+
+
+Hop = namedtuple('Hop', ('host', 'port', 'transport', 'prop'))
+
+
+def get_name(hop):
+    return "{}:{}:{}".format(
+        PORT_TO_LANG_NAME.get(hop.port, 'unknown'),
+        TRANSPORT_TO_TRANSPORT_NAME.get(hop.transport, 'unknown'),
+        PROP_TO_PROP_NAME.get(hop.prop, 'unknown'),
+    )
+
+
+def build_request(hops, id_=None):
+    if id_ is None:
+        id_ = service.rand63()
+
+    def build_service_hop(hop):
+        return pb2.ServiceHop(
+            service=pb2.Service(
+                name=get_name(hop),
+                port=hop.port,
+                host=hop.host,
+                spec=pb2.Spec(
+                    transport=hop.transport,
+                    propagation=hop.prop,
+                )
+            )
+        )
+
+    return pb2.TestRequest(
+        id=id_,
+        name=get_name(hops[0]),
+        service_hops=[build_service_hop(hop) for hop in hops]
+    )
+
+
+HTTP = pb2.Spec.HTTP
+GRPC = pb2.Spec.GRPC
+B3 = pb2.Spec.B3_FORMAT_PROPAGATION
+TRACECONTEXT = pb2.Spec.TRACE_CONTEXT_FORMAT_PROPAGATION
+BINARY = pb2.Spec.BINARY_FORMAT_PROPAGATION
+
+OWN_HOST = 'localhost'
+OWN_HTTP_PORT = pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT
+OWN_GRPC_PORT = pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT
+
+
+def test_http_server():
+    test_request = build_request([
+        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
+        Hop(OWN_HOST, OWN_HTTP_PORT, HTTP, TRACECONTEXT),
+    ])
+    with service.serve_http_tracecontext():
+        return service.call_http_tracecontext(
+            OWN_HOST, OWN_HTTP_PORT, test_request)
+
+
+def test_grpc_server():
+    test_request = build_request([
+        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
+        Hop(OWN_HOST, OWN_GRPC_PORT, GRPC, BINARY),
+    ])
+    with service.serve_grpc_binary():
+        return service.call_grpc_binary(
+            'localhost', OWN_GRPC_PORT, test_request)
+
+
+if __name__ == '__main__':
+    test_http_server()
+    test_grpc_server()

--- a/interoptest/src/pythonservice/util.py
+++ b/interoptest/src/pythonservice/util.py
@@ -1,3 +1,5 @@
+# Copyright 2018 Google LLC
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/interoptest/src/pythonservice/util.py
+++ b/interoptest/src/pythonservice/util.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# Copyright 2018 Google LLC
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/interoptest/src/pythonservice/util.py
+++ b/interoptest/src/pythonservice/util.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+import signal
+import threading
+
+try:
+    from contextlib import ExitStack
+except ImportError:
+    from contextlib2 import ExitStack
+
+
+SIGETC = (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+
+
+@contextmanager
+def set_signals(sigs, func):
+    """Temporarily set func as the action for multiple signals."""
+
+    with ExitStack() as stack:
+        for sig in sigs:
+            stack.enter_context(set_signal(sig, func))
+        yield stack
+
+
+@contextmanager
+def set_signal(sig, func):
+    """Temporarily change a signal's action to the given func."""
+    old_action = signal.signal(sig, func)
+    try:
+        yield
+    finally:
+        if old_action is not None:
+            signal.signal(sig, old_action)
+
+
+@contextmanager
+def get_signal_exit():
+    """Get an event that's set on SIG{INT,TERM,HUP}.
+
+    Restore the old signal action on exiting the context.
+    """
+    event = threading.Event()
+
+    def set_exit(signal_num, stack_frame):
+        event.set()
+
+    with set_signals(SIGETC, set_exit):
+        yield event


### PR DESCRIPTION
This diff adds HTTP and GRPC python services that implement `TestRequest`. Each service tries to register itself on start, and continues to serve requests until it's killed. They can be run as stand-alone scripts (e.g. `./grpcserver.py`) or from another python process as e.g. `grpcserver.main()` or `with grpcserver.serve_grpc_binary(): ...`.

This diff _doesn't_ check the trace context or tags, but I think it makes sense to split that into a separate PR.

I'm using flask here instead of e.g. `BaseHTTPServer` since opencensus-python ships with flask integration, but I've left the (uninstrumented) `BaseHTTPServer` service in here as WIP.